### PR TITLE
autosave playground code to localStorage on edit/run

### DIFF
--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -17,8 +17,27 @@ else {
 }
 `
 
-const editor = new Editor($("#editor"), code)
+// Load saved code from localStorage or use default
+const savedCode = localStorage.getItem('playground-code') || code;
 
+const editor = new Editor($("#editor"), savedCode)
+
+// Save code to localStorage whenever it changes
+let saveTimeout;
+editor.view.dom.addEventListener('input', () => {
+    // Debounce saving to avoid excessive localStorage writes
+    clearTimeout(saveTimeout);
+    saveTimeout = setTimeout(() => {
+        const currentCode = editor.getContent();
+        localStorage.setItem('playground-code', currentCode);
+    }, 500); 
+});
+
+// Also save when run button is clicked
+editor.runButton.on("click", () => {
+    const currentCode = editor.getContent();
+    localStorage.setItem('playground-code', currentCode);
+});
 
 
 


### PR DESCRIPTION
## Related Issue
Closes #9: Save playground code into local storage

## Summary
This adds autosave functionality to the **playground editor only**. User code is persisted to `localStorage` on input (debounced) and immediately when the run button is clicked. On page load, previously saved code is restored; if none exists, a default example snippet is used.

## Implementation Details
- **Storage key:** `playground-code`
- On initialization, the editor is seeded with either the saved code from `localStorage` or a default example.
- Listens to editor input events and debounces saving (500ms) to avoid excessive writes.
- Also saves immediately when the run button is clicked.
- Uses existing `Editor` API (`getContent()`) to retrieve current code.
- Scoped only to the playground editor — does not affect lesson or homepage editors.

### Key Code Snippet
```js
const savedCode = localStorage.getItem('playground-code') || code;
const editor = new Editor($("#editor"), savedCode);

let saveTimeout;
editor.view.dom.addEventListener('input', () => {
  clearTimeout(saveTimeout);
  saveTimeout = setTimeout(() => {
    const currentCode = editor.getContent();
    localStorage.setItem('playground-code', currentCode);
  }, 500);
});

editor.runButton.on("click", () => {
  const currentCode = editor.getContent();
  localStorage.setItem('playground-code', currentCode);
});
