### PR TITLE
Log errors to console on bad syntax

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -467,7 +467,11 @@ export class Editor {
 		var print = function () {};
 
 		const a = function () {
-			return eval(input + (test || ""));
+			try {
+				return eval(input + (test || ""));
+			} catch (error) {
+				logs.push(error.toString());
+			}
 		};
 
 		// Return the eval'd result


### PR DESCRIPTION
## Description
Currently, if you write some wrong code in the editor, it fails to run, displays full screen, and logs to the console. It would be better if we caught these errors and threw them to the user's terminal.

## Solution
The `eval()` in `safeEval()` evaluates code, but if bad syntax is given it throws an error. From [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval) "Throws any exception that occurs during evaluation of the code, including [SyntaxError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError) if script fails to be parsed as a script."

- Added a try catch block to the `eval()` so if bad syntax is given it will instead catch the error. We then log the error to the mocked console.

<img width="1579" height="795" alt="image" src="https://github.com/user-attachments/assets/69012326-bc8b-45af-a366-52e3a75a954c" />

Closes: #56 