### PR TITLE
updated readme and added contributing.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# 🧩 Contributing to SyntaxForge
+
+Thank you for your interest in contributing to **SyntaxForge**! 🎉  
+We welcome all kinds of contributions — from code and documentation to design and ideas.
+
+---
+
+## 🚀 Getting Started
+
+1. **Fork** the repository  
+2. **Clone** your fork:
+   ```bash
+   git clone https://github.com/your-username/SyntaxForge.git
+   cd SyntaxForge
+3. Create a branch:
+    git checkout -b feature/your-feature-name
+4. Make your changes ,test them and add them.   
+   git add <file>
+5. Commit and push:
+   git commit -m "Add: your feature name"
+   git push origin feature/your-feature-name
+6. Open a Pull Request (PR) to the main repository.
+
+🧱 Contribution Guidelines
+Follow existing code style and conventions
+Add helpful commit messages
+Update documentation if your changes affect it
+Test your code before submitting
+Ensure mobile responsiveness for UI changes
+
+⚙️ Issue Assignment & PR Rules
+Comment on an issue before starting work on it.
+Once assigned, please start working on it within 1–2 days.
+Submit your PR within 7 days of assignment if possible.
+Communicate if you need more time — we’re happy to extend your assignment if you’re active.
+
+🕒 Unassignment Policy for Inactive Contributors
+To keep contributions active and fair for everyone:
+If a contributor is inactive for more than 7 days after being assigned to an issue, the maintainer will unassign them.
+Inactivity means no visible progress, communication, or PR submission.
+Once unassigned, the issue becomes open for new contributors to pick up.
+
+💡 Why This Exists
+Prevents issue backlog and stalled progress
+Ensures fairness and opportunity for others (especially during Hacktoberfest)
+Keeps the project active and collaborative
+
+💬 Need Help?
+If you’re unsure about anything:
+Open a discussion or comment under an issue
+Tag the maintainers
+Check the README
+
+❤️ Thank You
+Your contributions make SyntaxForge better for everyone!
+We’re excited to see what you’ll build and improve. 🚀
+   
+   

--- a/README.md
+++ b/README.md
@@ -195,6 +195,25 @@ SyntaxForge is officially participating in **Hacktoberfest**! 🎉
 - **Documentation**: Update docs for new features
 - **Responsive Design**: Ensure changes work on mobile devices
 
+🕒 Unassignment Policy for Inactive Contributors
+mTo keep contributions active and fair for everyone, we’ve added an Unassignment Clause to our contributing process.
+
+🔁 Unassignment Clause
+If a contributor is inactive for more than 7 days after being assigned to an issue, the maintainer reserves the right to unassign them.
+Inactivity includes not responding to comments, not submitting any progress updates, or not opening a PR within a week.
+Once unassigned, the issue becomes open for new contributors.
+
+⚙️ How It Works
+A contributor is assigned to an issue.
+If no progress (PR or update) is made within 7 days, a reminder comment will be added.
+If there’s still no response, the issue will be automatically or manually unassigned.
+New contributors can then take up the issue.
+
+💡 Why This Policy Exists
+Keeps the project active and prevents issue backlog.
+Encourages contributors to stay engaged and communicate.
+Ensures fair opportunities for new participants during events like Hacktoberfest.
+
 Ready to contribute? **[Check out our open issues!](https://github.com/your-username/SyntaxForge/issues)**
 
 **New to contributing?** Check out our comprehensive [Contributing Guide](CONTRIBUTING.md) for detailed setup instructions and guidelines.


### PR DESCRIPTION
the changes i have made :
1. Added Unassignment Clause – inactive contributors (7+ days) can be unassigned
2. Explained how it works – unassigned issues become available for others
3. Explained why – prevents backlog, ensures fairness during Hacktoberfest
4. Updated README – added note under Hacktoberfest Guidelines
5. Created CONTRIBUTING.md – full workflow and unassignment policy
6. closes #67 