### PR TITLE
added unassigment clause

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -167,20 +167,20 @@ I've forked the repo and started working on a fix for this issue. Will open a PR
 
 This helps avoid duplicate work and encourages collaboration.
 
-##Unassignment Policy for Inactive Contributors
+## Unassignment Policy for Inactive Contributors
 
- ###To ensure active contribution and fair opportunities for everyone:
+**To ensure active contribution and fair opportunities for everyone:**
 
-  If a contributor is inactive for 7 days after being assigned to an issue (no PR, no progress updates, or no communication),
-  the maintainer may unassign them from that issue.
+If a contributor is inactive for 7 days after being assigned to an issue (no PR, no progress updates, or no communication),
+the maintainer may unassign them from that issue.
 
-  This allows new contributors to take over and prevents issues from becoming stale.
+This allows new contributors to take over and prevents issues from becoming stale.
 
-  If you need more time, please comment on the issue to request an extension.
+If you need more time, please comment on the issue to request an extension.
 
-  Reassignments are always done respectfully and transparently.
+Reassignments are always done respectfully and transparently.
 
- Reason: This policy helps maintain a healthy workflow, encourages consistent participation, and ensures that issues don’t remain blocked during events like Hacktoberfest.
+Reason: This policy helps maintain a healthy workflow, encourages consistent participation, and ensures that issues don’t remain blocked during events like Hacktoberfest.
 
 ## Making Code Changes
 


### PR DESCRIPTION
what i have done:
Added an Unassignment Clause section to the CONTRIBUTING.md file, explaining that inactive issues will be automatically unassigned after 7 days of inactivity. This ensures smoother collaboration and prevents issues from being blocked or abandoned.
cloeses #67 