### PR TITLE
fix: ensure lessons section visible on mobile by adjusting flex align…

### DIFF
--- a/src/pages/course.html
+++ b/src/pages/course.html
@@ -36,7 +36,7 @@
 		</header>
 
 		<main
-			class="place-content-start place-items-start col gap-12 flex-wrap md:flex-nowrap md:px-60"
+			class="flex flex-col items-start justify-start gap-12 px-6 md:px-60"
 		>
 			<div class="col w-full">
 				<h1 class="text-2xl md:text-3xl font-extrabold" id="name"></h1>


### PR DESCRIPTION
### Description
The `#lessons` section was not visible on screens smaller than 768px due to the `.col` utility applying centered flex alignment (`place-items-center`). This caused the content to collapse visually even though it existed in the DOM.

### Fix
- Replaced `.col` with explicit `flex flex-col items-start justify-start` on the `<main>` container.
- Removed unnecessary `flex-wrap` for a cleaner layout.
- Ensured consistent spacing and alignment across breakpoints.

### Result
- Lessons section is now visible and properly aligned on mobile and tablet devices.
- Layout remains consistent and readable across all screen sizes.

---

### Related Issue
Closes #49 
