### PR TITLE
bug: No favicon on docs #78

### DIFF
--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,11 +1,14 @@
 {
-    "source": {
-        "include": ["src/js"],
-        "includePattern": ".+\\.js$",
-        "excludePattern": "(node_modules|docs)"
-    },
-    "opts": {
-        "template": "node_modules/clean-jsdoc-theme",
-        "destination": "./docs"
+  "source": {
+    "include": ["src/js"],
+    "includePattern": ".+\\.js$",
+    "excludePattern": "(node_modules|docs)"
+  },
+  "opts": {
+    "template": "node_modules/clean-jsdoc-theme",
+    "destination": "./docs",
+    "theme_opts": {
+      "favicon": "logo.png"
     }
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -167,6 +167,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.1.tgz",
       "integrity": "sha512-5kS1U7emOGV84vxC+ruBty5sUgcD0te6dyupyRVG2zaSjhTDM73LhVKUtVwiqSe6QwmEoA4SCiU8AKPFyumAWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -233,6 +234,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
       "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -242,6 +244,7 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.0.tgz",
       "integrity": "sha512-yvSchUwHOdupXkd7xJ0ob36jdsSR/I+/C+VbY0ffBiL5NiSTEBDfB1ZGWbbIlDd5xgdUkody+lukAdOxYrOBeg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -328,6 +331,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.13.2.tgz",
       "integrity": "sha512-jwtMmJa1BXXDCiDx1vC6SFN/+HfYG53UkfJa6qeN5ogvOunzbFDO3wISZy5n9xgYFUrEP6M7e8EG++riHNTv9w==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.18",
         "@firebase/logger": "0.4.4",
@@ -394,6 +398,7 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.4.2.tgz",
       "integrity": "sha512-LssbyKHlwLeiV8GBATyOyjmHcMpX/tFjzRUCS1jnwGAew1VsBB4fJowyS5Ud5LdFbYpJeS+IQoC+RQxpK7eH3Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@firebase/app": "0.13.2",
         "@firebase/component": "0.6.18",
@@ -409,7 +414,8 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@firebase/auth": {
       "version": "1.10.8",
@@ -860,6 +866,7 @@
       "integrity": "sha512-zGlBn/9Dnya5ta9bX/fgEoNC3Cp8s6h+uYPYaDieZsFOAdHP/ExzQ/eaDgxD3GOROdPkLKpvKY0iIzr9adle0w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -1492,6 +1499,7 @@
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
       "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -2021,6 +2029,7 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -2421,6 +2430,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -2682,6 +2692,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -5105,6 +5116,7 @@
       "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.4.tgz",
       "integrity": "sha512-zeFezwyXeG4syyYHbvh1A967IAqq/67yXtXvuL5wnqCkFZe8I0vKfm+EO+YEvLguo6w9CDUbrAXVtJSHh2E8rw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.15",
         "@jsdoc/salty": "^0.2.1",
@@ -6480,6 +6492,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7800,6 +7813,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7857,7 +7871,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -8029,6 +8044,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.9.tgz",
       "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -8077,6 +8093,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "serve": "webpack serve",
     "build": "webpack",
-    "docs": "jsdoc -c jsdoc.json --readme README.md"
+    "docs:copy-favicon": "node -e \"require('fs').copyFileSync('src/imgs/logo.png', 'docs/logo.png')\"",
+    "docs": "jsdoc -c jsdoc.json --readme README.md && npm run docs:copy-favicon"
   },
   "dependencies": {
     "@codemirror/commands": "^6.8.1",


### PR DESCRIPTION
## Description
Fixes the missing favicon on the JSDoc documentation site (`docs.syntaxforge.dev`).

The `clean-jsdoc-theme` was failing to generate the favicon link and copy the asset.

## Changes
1.  **Configured `jsdoc.json`**: Moved the `favicon` setting to the correct `opts.theme_opts` path to ensure the HTML link is properly generated.
2.  **Optimized `package.json`**: Added a robust, cross-platform Node.js file-copy command to the `docs` script to explicitly move `src/imgs/logo.png` to the required `docs/logo.png` location.

## Type of Change
- [x] Bug fix

## Related Issue
Closes #78

## Checklist
- [x] My code follows the style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings